### PR TITLE
feat: 跟其他语言的示例保持一致的体验

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ def make_app():
         (r"/api/sendMessageCard", handlers.dingtalk.MessageCardHandler),
         (r"/api/sendTopCard", handlers.dingtalk.TopBoxHandler),
         (r"/", handlers.MainHandler),
+        (r"/index.html", handlers.MainHandler),
         (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": os.path.join(PROJECT_ROOT, "static")})
     ],
         login_url="/auth/login",
@@ -44,10 +45,11 @@ def make_app():
 
 async def main():
     logging.basicConfig(format="%(asctime)s %(filename)s(%(lineno)s): %(levelname)-5s %(message)s", level=logging.INFO)
-    logging.info("listen port 8080")
+    port = 7001
+    logging.info("listen port %d", port)
 
     app = make_app()
-    app.listen(8080)
+    app.listen(port)
     await asyncio.Event().wait()
 
 

--- a/handlers/main_handler.py
+++ b/handlers/main_handler.py
@@ -45,4 +45,6 @@ class MainHandler(handlers.base.AuthHandler):
                 if not UtilClient.empty(err.code) and not UtilClient.empty(err.message):
                     logging.error("GetSceneGroupInfoRequest(), code=%s, msg=%s" % (err.code, err.message))
                     pass
-        self.render("home.html", group_info=group_info)
+        self.render("home.html",
+                    group_info=group_info,
+                    service_url=self.request.full_url())

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,76 +5,78 @@
 {% block content %}
 
     <div class="row">
-		<div class="col-md-12">
-			<div class="jumbotron">
-				<h2 class="text-center">
-					酷应用配置成功！
-				</h2>
-				<p class="text-center sub-title">
-					已成功接入账号免登、消息卡片、吊顶卡片功能，点击下方模拟发送体验卡片效果。
-				</p>
-			</div>
-		</div>
-	</div>
+        <div class="col-md-12">
+            <div class="jumbotron">
+                <h2 class="text-center">
+                    酷应用配置成功！
+                </h2>
+                <p class="text-center sub-title">
+                    当前服务地址：{{ service_url }}
+                    <br />
+                    点击下方模拟发送体验卡片效果
+                </p>
+            </div>
+        </div>
+    </div>
 
-	<div class="row">
-		<div class="col-md-12">
-			<h3 class="text-left">
-				已接入钉钉免登录
-			</h3>
-			<p class="sub-title">
-				通过钉钉免登录功能，可以获取有效用户身份。
-			</p>
-			<div class="media">
+    <div class="row">
+        <div class="col-md-12">
+            <h3 class="text-left">
+                已接入钉钉免登录
+            </h3>
+            <p class="sub-title">
+                通过钉钉免登录功能，可以获取有效用户身份。
+            </p>
+            <div class="media">
                 <img class="mr-3 avatar" alt="avatar" src="{{ current_user["avatarUrl"] }}">
-				<div class="media-body">
-					<h5 class="mt-0">
+                <div class="media-body">
+                    <h5 class="mt-0">
                         你好，{{ current_user["nick"] }}
-					</h5>
-					<p class="sub-title">
-						此处显示你的名字表示已经成功完成免登录
-					</p>
-				</div>
-			</div>
-		</div>
-	</div>
+                    </h5>
+                    <p class="sub-title">
+                        此处显示你的名字表示已经成功完成免登录
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
 
-	<div class="row">
-		<div class="col-md-12">
-			<h3>
-				发送文本消息
-			</h3> 
-			<div class="input-group">
-				<input type="text" class="form-control" id="textMessage">
-			</div>
-			<hr />
-			<button type="button" class="btn btn-md btn-block btn-primary" onclick="sendTextMessage()">
-				试一试
-			</button>
-		</div>
-	</div>
+    <div class="row">
+        <div class="col-md-12">
+            <h3>
+                发送文本消息
+            </h3>
+            <div class="input-group">
+                <input type="text" class="form-control" id="textMessage">
+            </div>
+            <hr />
+            <button type="button" class="btn btn-md btn-block btn-primary" onclick="sendTextMessage()">
+                试一试
+            </button>
+        </div>
+    </div>
 
-	<div class="row">
-		<div class="col-md-12">
-			<h3>
-				发送消息卡片
-			</h3> 
-			<hr />
-			<button type="button" class="btn btn-md btn-block btn-primary" onclick="sendCardMessage()">
-				试一试
-			</button>
-		</div>
-	</div>
+    <div class="row">
+        <div class="col-md-12">
+            <h3>
+                发送消息卡片
+            </h3>
+            <hr />
+            <button type="button" class="btn btn-md btn-block btn-primary" onclick="sendCardMessage()">
+                试一试
+            </button>
+        </div>
+    </div>
 
-	<div class="row">
-		<div class="col-md-12">
-			<h3>
-				发送吊顶卡片
-			</h3> 
-			<hr />
-			<button type="button" class="btn btn-md btn-block btn-primary" onclick="sendTopMessage()">
-				试一试
-			</button>
-		</div>
-	</div>
+    <div class="row">
+        <div class="col-md-12">
+            <h3>
+                发送吊顶卡片
+            </h3>
+            <hr />
+            <button type="button" class="btn btn-md btn-block btn-primary" onclick="sendTopMessage()">
+                试一试
+            </button>
+        </div>
+    </div>
 {% end %}


### PR DESCRIPTION
- 监听端口从8080改为7001
- 首页地址为 /index.html
- 页面增加url地址，便于开发者自助诊断问题
- 样式：\t换成空格

Signed-off-by: 金喜 <jinxi.kj@taobao.com>